### PR TITLE
Added Schedule Exporting

### DIFF
--- a/scheduler.js
+++ b/scheduler.js
@@ -248,12 +248,15 @@ function VEventObject(timeBlocks) {
 
     // Update the start date of the class to the first day where there is
     // actually a class (according to the MTWRF flags)
-    var day = this.weekdays[0] + 1
-    var daysTillFirstClass = (7 + day - this.startDate.getDay()) % 7;
+    var startDay = this.startDate.getDay();
+    var daysTillClasses = this.weekdays.map( function(weekday) {
+      day = weekday + 1;
+      return (7 + day - startDay) % 7;
+    });
+    var daysTillFirstClass = Math.min.apply(null, daysTillClasses);
     this.startDate.setDate(this.startDate.getDate() + daysTillFirstClass);
 
     this.endDate = new Date(Date.parse(timeBlocks[0].course.data.endDate));
-    this.endDate.setDate(this.endDate.getDate() + daysTillFirstClass);
     this.name = timeBlocks[0].course.name;
     var locationRegex = /[^;]*$/;
     this.loc = timeBlocks[0].loc;

--- a/scheduler.js
+++ b/scheduler.js
@@ -235,7 +235,7 @@ function exportSchedule(mapOfCourses) {
 function formatDate(date) {
 	var isostr = date.toISOString();
 	var dotIndex = isostr.indexOf('.');
-	return isostr.substring(0, dotIndex).replace(/-/g, '').replace(/:/g, '');
+	return isostr.substring(0, dotIndex).replace(/-/g, '').replace(/:/g, '') + 'Z';
 }
 
 function VEventObject(timeBlocks) {
@@ -326,7 +326,7 @@ function generateSchedules(courses) {
 			});
 			return args;
 			
-		});	
+		});
 	});
 	
 	// Generate all possible combinations

--- a/scheduler.js
+++ b/scheduler.js
@@ -305,6 +305,19 @@ function buildVEvent(timeBlock, i) {
   var rrule = 'RRULE:FREQ=WEEKLY;BYDAY=' + daysString + ';UNTIL=';
 }
 
+function mapCourses(schedules) {
+  var mapCourses = new Object();
+  for (int i = 0; i < schedules.length; i++) {
+    var timeBlock = schedules[i];
+    var name = timeBlock.course.name;
+    if (mapCourses[name] == undefined) {
+    	mapCourses[name] = [timeBlock];
+    } else {
+    	mapCourses[name].add(timeBlock);
+    }
+  }
+  return mapCourses;
+}
 
 function generateSchedules(courses) {
 
@@ -635,7 +648,11 @@ function messageOnce(str) {
 	};
 	
 	document.getElementById('button-export').onclick = function () {
-		var schedule = JSON.parse(JSON.stringify(schedules[schedulePosition]));
+		var mapOfCourses = mapCourses(schedules[schedulePosition]);
+		for (int i = 0; i < mapOfCourses.length; i++) {
+		   
+		//var schedule = JSON.parse(JSON.stringify(schedules[schedulePosition]));
+		
 		exportSchedule(schedule, "testing.ics");
 	};
 	// Silly workaround to circumvent crossdomain policy

--- a/scheduler.js
+++ b/scheduler.js
@@ -132,7 +132,6 @@ function loadSchedule(schedules, i) {
 }
 
 function drawSchedule(schedule) {
-	console.log(schedule);
 	var days = Array.prototype.slice.call(document.querySelectorAll('.day'));
 	var beginHour = 8 - 0.5; // Starts at 8am
 	var hourHeight = document.querySelector('#schedule li').offsetHeight;
@@ -302,10 +301,8 @@ function mapCourses(schedules) {
 }
 
 function generateSchedules(courses) {
-
 	// Parse all the courses from text form into a list of courses, each a list of time slots
 	var classes = courses.filter(function (course) { return course.selected && course.times; }).map(function (course) {
-	
 		// Parse every line separately
 		return course.times.split('\n').map(function (timeSlot) {
 		
@@ -314,14 +311,13 @@ function generateSchedules(courses) {
 			
 			// Split it into a list of each day's time slot
 			var args = [];
-			timeSlot.replace(/([MTWRF]+) (\d?\d):(\d\d)\s*(AM|PM)?\s*\-\s?(\d?\d):(\d\d)\s*(AM|PM)?;([^;]*)/gi, function (_, daylist, h1, m1, pm1, h2, m2, pm2, lextra) {
+			timeSlot.replace(/([MTWRF]+) (\d?\d):(\d\d)\s*(AM|PM)?\s*\-\s?(\d?\d):(\d\d)\s*(AM|PM)?;([^;]*?)(?=$|, \w+ \d?\d:\d{2})/gi, function (_, daylist, h1, m1, pm1, h2, m2, pm2, loc) {
 				daylist.split('').forEach(function (day) {
-					var loc = lextra.substring(0,lextra.lastIndexOf(',')) || lextra;
 					args.push({
 						'course': course,
 						'section': section,
-						'loc': loc,
-						'weekday': 'MTWRF'.indexOf(day), 
+						'loc': loc.trim().replace(/\s*/,' ').replace(/^\s/, ''),
+						'weekday': 'MTWRF'.indexOf(day),
 						'from': timeToHours(+h1, +m1, (pm1 || pm2).toUpperCase() == 'PM'),
 						'to': timeToHours(+h2, +m2, (pm2 || pm1).toUpperCase() == 'PM'),
 					});
@@ -531,8 +527,6 @@ function messageOnce(str) {
 			data['timeSlots'].filter(function (timeSlot) {
 					// Make sure they're actually of the correct format
 					return /([MTWRF]+) (\d?\d):(\d\d)\s*(AM|PM)?\s*\-\s?(\d?\d):(\d\d)\s*(AM|PM)?/gi.test(timeSlot);
-				}).map(function (timeSlot) {
-					return timeSlot.split('.')[0];
 				}).filter(function (timeSlot, i, arr) {
 					// Remove duplicates
 					return arr.lastIndexOf(timeSlot) == i;
@@ -635,7 +629,7 @@ function messageOnce(str) {
 		var mapOfCourses = mapCourses(schedules[schedulePosition]);
 		
 		var scheduleText = exportSchedule(mapOfCourses); 
-		download("testing.ics", scheduleText);
+		download("schedule.ics", scheduleText);
 	};
 	// Silly workaround to circumvent crossdomain policy
 	if (window.opener)

--- a/scheduler.js
+++ b/scheduler.js
@@ -292,7 +292,7 @@ function mapCourses(schedules) {
     if (mapOfCourses[key] == undefined) {
     	mapOfCourses[key] = [timeBlock];
     } else {
-    	mapOfCourses[key].add(timeBlock);
+    	mapOfCourses[key].push(timeBlock);
     }
   }
   return mapOfCourses;


### PR DESCRIPTION
We added a button to the main interface which allows the user to export the currently displayed schedule in the iCal format (which can be imported by Google Calendar, iCal, and more).

Also, we removed part of your pipeline which split string descriptions of timeSlots at the first period. This cut off the end of locations which had periods in them, and didn't seem to have any legitimate purpose.

Love,
Alex, Jonathan, and Lisa
