### PR TITLE
Fixed Bug with multi-timeslot classes.

### DIFF
--- a/scheduler.js
+++ b/scheduler.js
@@ -299,7 +299,7 @@ function mapCourses(schedules) {
 	var mapOfCourses = {};
 	for (var i = 0; i < schedules.length; i++) {
 		var timeBlock = schedules[i];
-		var key = timeBlock.course.name + timeBlock.loc;
+		var key = timeBlock.course.name + timeBlock.loc + (' ' + timeBlock.from + ' ' + timeBlock.to);
 		if (!mapOfCourses[key])
 			mapOfCourses[key] = [];
 		mapOfCourses[key].push(timeBlock);


### PR DESCRIPTION
Multi-timeslot classes with the same room for both timeslots were
improperly being lumped into the same timeslot during export.

This was happening because for some reason timeslots were being keyed
by course name + room (and not actual times). Now their keys include times.
