### PR TITLE
Add Claremont Review links to Scheduler + minor bug fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 							<a class="c" href="#" title="Change color">c</a>
 						</div>
 						<div class="course-input">
-							<input type="text" placeholder="Course Name" />
+							<input class="withReview" type="text" placeholder="Course Name" />
 							<div id="course-review">
 								<a class="r" href="http://claremontreview.com/" target="blank" title="Course Review">Cr</a>
 							</div>

--- a/index.html
+++ b/index.html
@@ -30,8 +30,8 @@
 			<h1>Courses
 				<span id="credit-counter"></span>
 			</h1>
-      <label class="check-label">Allow Conflicts<input id="button-conflicts" type="checkbox" /></label>
-      <label class="check-label">Show Sections<input id="button-sections" type="checkbox" title="Section numbers?" /></label>
+			<label class="check-label">Allow Conflicts<input id="button-conflicts" type="checkbox" /></label>
+			<label class="check-label">Show Sections<input id="button-sections" type="checkbox" title="Section numbers?" /></label>
 			<label class="check-label">Show Review Links<input id="button-reviews" type="checkbox" title="Display links to ClaremontReview?"  /></label>
 			<button id="button-add">+</button>
 			<button id="button-generate" disabled="disabled">Generate</button>

--- a/index.html
+++ b/index.html
@@ -6,19 +6,19 @@
 	</head>
 	<body>
 		<div id="controls">
-			<h1>Scheduler 
+			<h1>Scheduler
 				<span id="page-counter" class="not-empty">
 					<span id="pages">(<span id="page-number">1</span> of <span id="page-count">1</span>)</span>
 					<span id="pages-not-possible">(no schedules possible)</span>
 				</span>
-				<button id="button-right" disabled="disabled" title="(you can also use your arrow keys)">&gt;</button> 
+				<button id="button-right" disabled="disabled" title="(you can also use your arrow keys)">&gt;</button>
 				<button id="button-left" disabled="disabled" title="(you can also use your arrow keys)">&lt;</button>
 			</h1>
-			
+
 			<div class="text">
 				Here's a tool to help you arrange the classes you want to take. Give it all the sections of the classes you want, and it'll tell you all compatible permutations. Here's how to use it:
 				<ol>
-					<li>Drag this <a href="#" id="bookmarklet">Scheduler</a> bookmarklet to your <a id="bookmark-helper">bookmarks bar</a> 
+					<li>Drag this <a href="#" id="bookmarklet">Scheduler</a> bookmarklet to your <a id="bookmark-helper">bookmarks bar</a>
 						<span style="font-size: 0.8em">(you need to drag it &mdash; just bookmarking this page will not work!)</span>
 					</li>
 					<li>Go to Portal and click the Scheduler bookmarklet</li>
@@ -26,14 +26,14 @@
 					<li>Navigate possible schedules using the arrows above!</li>
 				</ol>
 			</div>
-			
-			<h1>Courses 
+
+			<h1>Courses
 				<span id="credit-counter"></span>
 			</h1>
-                                <label class="check-label">Allow Conflicts<input id="button-conflicts" type="checkbox" title="Section numbers?" /></label>
-                                <label class="check-label">Show Sections<input id="button-sections" type="checkbox" title="Section numbers?" /></label>
-				<button id="button-add">+</button>
-				<button id="button-generate" disabled="disabled">Generate</button>
+      <label class="check-label">Allow Conflicts<input id="button-conflicts" type="checkbox" /></label>
+      <label class="check-label">Show Sections<input id="button-sections" type="checkbox" title="Section numbers?" /></label>
+			<button id="button-add">+</button>
+			<button id="button-generate" disabled="disabled">Generate</button>
 			<div id="courses-container">
 				<div id="courses-filler" class="text">Click the add button or use the bookmarklet above to get started!</div>
 				<div id="courses">
@@ -50,7 +50,7 @@
 					</div>
 				</div>
 			</div>
-			
+
 			<h1>Starred Schedules
 				<button id="button-save" disabled="disabled" title="Star">&#9733;</button>
 				<button id="button-print" disabled="disabled" title="Print">Print</button>
@@ -60,7 +60,7 @@
 				<div id="saved-schedules-filler">Generate some schedules and star the ones you like!</div>
 				<div id="saved-schedules"></div>
 			</div>
-			
+
 			<h1>Notes</h1>
 			<div class="text">
 				<ul>
@@ -70,7 +70,7 @@
 				Bugs or suggestions? <a href="mailto:aozdemir@hmc.edu">Email me</a> or <a href="https://github.com/hmc-tools/hmc-scheduler" target="_blank">fork it on GitHub</a>!
 			</div>
 		</div>
-	
+
 		<table id="schedule" border="1" cellspacing="3" cellpadding="1">
 			<tr>
 				<th></th>
@@ -106,7 +106,7 @@
 				<td><div class="day"></div></td>
 			</tr>
 		</table>
-		
+
 		<!-- This code is to be run on Portal pages. All multiple spaces and /* comments */ will be replaced with a single space.
 			 Be careful not to use // line comments, as new lines will be replaced with spaces! -->
 		<script type="text/x-js-bookmarklet">
@@ -119,14 +119,14 @@
 				window.location = __URL__ + '#!bookmarklet';
 				return;
 			}
-			
+
 			var loader = false;
-			
+
 			/* Clear this page and replace it with a full-page frame */
 			while (document.body.firstChild)
 				document.body.removeChild(document.body.firstChild);
 			document.body.parentNode.style.height = document.body.style.height = '100%';
-			
+
 			var frame = document.createElement('iframe');
 			frame.src = '/ICS/Course_Registration/';
 			frame.style.position = 'fixed';
@@ -134,9 +134,9 @@
 			frame.style.top = frame.bottom = frame.style.border = 0;
 			frame.onload = function () {
 				var document = frame.contentWindow.document;
-				
+
 				/* Add the "schedule" links */
-				Array.prototype.filter.call(document.querySelectorAll('.groupedGrid tr:not(.subItem)'), function (node) { 
+				Array.prototype.filter.call(document.querySelectorAll('.groupedGrid tr:not(.subItem)'), function (node) {
 					return node.children.length == 10 && node.children[0].nodeName == 'TD';
 				}).forEach(function (row) {
 					var data = {
@@ -154,11 +154,11 @@
 					var link = document.createElement('a');
 					link.href = '#';
 					link.innerHTML = 'Schedule';
-					link.onclick = function () { 
+					link.onclick = function () {
 						this.style.color = 'black';
 						this.style.textDecoration = 'none';
 						this.innerHTML = 'section added';
-						
+
 						if (!loader || loader.closed) {
 							loader = window.open(__URL__ + '#!v=' + __VERSION__, 'loader', 'resizable=yes, scrollbars=yes, titlebar=yes, width=1300, height=700, top=10, left=300');
 
@@ -171,31 +171,31 @@
 							}, false);
 						} else
 							loader.postMessage(JSON.stringify(data), '*');
-							
+
 						return false;
 					};
 					row.children[0].insertBefore(link, row.children[0].firstChild);
 				});
-				
+
 				/* Give some indication that we're modifying the page */
 				document.querySelector('a[title="Course Registration"]').innerHTML += ' + Scheduler';
 			};
 			document.body.appendChild(frame);
-			
+
 			/* Show a help message if they haven't seen it before. */
 			if ((localStorage.helpMessage || 0) < 1) {
 				localStorage.helpMessage = 1;
 				alert('Search for some classes, and you\'ll see a "schedule" link next to each result. Add every section of a class you\'re interested in, and then you can generate all possible schedules!');
 			}
-			
+
 			window.onbeforeunload = function () {
 				return 'Portal doesn\'t like it when you refresh or press the back button. Are you sure you want to continue?';
 			};
-			
+
 		</script>
-		
+
 		<script src="scheduler.js?v=3" type="text/javascript"></script>
-		
+
 		<script type="text/javascript">
 			addEventListener('load', function () {
 				window._gstc_lt = +new Date;

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
 			</h1>
       <label class="check-label">Allow Conflicts<input id="button-conflicts" type="checkbox" /></label>
       <label class="check-label">Show Sections<input id="button-sections" type="checkbox" title="Section numbers?" /></label>
+			<label class="check-label">Show Review Links<input id="button-reviews" type="checkbox" title="Display links to ClaremontReview?"  /></label>
 			<button id="button-add">+</button>
 			<button id="button-generate" disabled="disabled">Generate</button>
 			<div id="courses-container">

--- a/index.html
+++ b/index.html
@@ -45,6 +45,9 @@
 						</div>
 						<div class="course-input">
 							<input type="text" placeholder="Course Name" />
+							<div id="course-review">
+								<a class="r" href="http://claremontreview.com/" target="blank" title="Course Review">Cr</a>
+							</div>
 							<textarea placeholder="EXAM010 HM-01 (Staff): MWF 01:15PM-02:30PM"></textarea>
 						</div>
 					</div>

--- a/scheduler.css
+++ b/scheduler.css
@@ -32,7 +32,7 @@ table ol {
 }
 
 table li {
-	padding: 1.7em 0.25em;	
+	padding: 1.7em 0.25em;
 }
 
 th {
@@ -109,11 +109,11 @@ td {
 	float: right;
 	width: 92%;
 }
-.course input[type="text"], .course textarea {
+.course input[type="text"], .course textarea, .course #course-review {
 	width: 98%;
 	font-family: inherit;
 	padding: 3px;
-	border: 1px solid #999;	
+	border: 1px solid #999;
 	float: right;
 }
 .course input[type="text"] {
@@ -131,12 +131,28 @@ td {
 .course a {
 	display: block;
 }
+.course #course-review {
+	width: 5%;
+	display: none;
+	float: right;
+	padding: 2px 4px;
+}
+a.r {
+	text-align: center;
+}
+.course input[type="text"].withReview {
+	float: left;
+	width: 90%;
+}
 
 .course.hidden textarea, .course.hidden a {
 	display: none;
 }
 .course.hidden {
 	margin: 0.25em 0;
+}
+.course.hidden a.r {
+	display: block;
 }
 
 #courses {
@@ -150,7 +166,7 @@ td {
 	font-family: inherit;
 	padding: 3px;
 	border: 1px solid #999;
-	display: block;				
+	display: block;
 	margin: 1em auto;
 	width: 90%;
 }

--- a/scheduler.js
+++ b/scheduler.js
@@ -1,6 +1,7 @@
 var options = {
   'showSections': false,
-  'allowConflicts': false
+  'allowConflicts': false,
+  'showReviewLinks': false
 };
 
 function randomColor(seed) {
@@ -31,6 +32,13 @@ function addCourse(course, i, courses) {
   courseNode.querySelector('input[type="checkbox"]').checked = course.selected;
   if (course.times) courseNode.querySelector('textarea').value = course.times;
   courseNode.querySelector('input[type="text"]').style.backgroundColor = course.color || randomColor(course.name);
+
+  // Add and style review links
+  if (course.data && course.data['courseCode']) // Replace spaces with _ and trim off section
+    courseNode.querySelector('a.r').href = "http://claremontreview.com/courses/" + course.data['courseCode'].replace(/\s/g, '_').slice(0, -3);
+  courseNode.querySelector('#course-review').style.backgroundColor = courseNode.querySelector('input[type="text"]').style.backgroundColor;
+  if (options.showReviewLinks) courseNode.querySelector('#course-review').style.display = "block";
+  else courseNode.querySelector('input[type="text"]').classList.remove('withReview');
 
   // Collapsing and expanding
   courseNode.querySelector('input[type="text"]').onfocus = function () {
@@ -519,6 +527,27 @@ function messageOnce(str) {
   document.getElementById('button-conflicts').checked = options.allowConflicts = localStorage.allowConflicts;
   document.getElementById('button-conflicts').onclick = function () {
     localStorage.allowConflicts = options.allowConflicts = this.checked;
+    document.getElementById('button-generate').onclick();
+  };
+
+  document.getElementById('button-reviews').checked = options.showReviewLinks = localStorage.showReviewLinks;
+  document.getElementById('button-reviews').onclick = function () {
+    // Display/Hide Cr links
+    var courseNameNodes = document.querySelectorAll('#course-template input[type="text"]');
+    var courseReviewNodes = document.querySelectorAll('#course-template #course-review');
+    if (this.checked) {
+      for (var i = 1; i < courseNameNodes.length; i++) { // start from 1 as 0 is template
+        courseNameNodes[i].classList.add('withReview');
+        courseReviewNodes[i].style.display = "block";
+      }
+    } else {
+      for (var i = 1; i < courseNameNodes.length; i++) { // start from 1 as 0 is template
+        courseNameNodes[i].classList.remove('withReview');
+        courseReviewNodes[i].style.display = "none";
+      }
+    }
+    
+    localStorage.showReviewLinks = options.showReviewLinks = this.checked;
     document.getElementById('button-generate').onclick();
   };
 

--- a/scheduler.js
+++ b/scheduler.js
@@ -518,19 +518,19 @@ function messageOnce(str) {
     this.disabled = true;
   };
 
-  document.getElementById('button-sections').checked = options.showSections = localStorage.showSections;
+  document.getElementById('button-sections').checked = options.showSections = (localStorage.showSections === 'true');
   document.getElementById('button-sections').onclick = function () {
     localStorage.showSections = options.showSections = this.checked;
     document.getElementById('button-generate').onclick();
   };
 
-  document.getElementById('button-conflicts').checked = options.allowConflicts = localStorage.allowConflicts;
+  document.getElementById('button-conflicts').checked = options.allowConflicts = (localStorage.allowConflicts === 'true');
   document.getElementById('button-conflicts').onclick = function () {
     localStorage.allowConflicts = options.allowConflicts = this.checked;
     document.getElementById('button-generate').onclick();
   };
 
-  document.getElementById('button-reviews').checked = options.showReviewLinks = localStorage.showReviewLinks;
+  document.getElementById('button-reviews').checked = options.showReviewLinks = (localStorage.showReviewLinks === 'true');
   document.getElementById('button-reviews').onclick = function () {
     // Display/Hide Cr links
     var courseNameNodes = document.querySelectorAll('#course-template input[type="text"]');

--- a/scheduler.js
+++ b/scheduler.js
@@ -35,7 +35,7 @@ function addCourse(course, i, courses) {
 
   // Add and style review links
   if (course.data && course.data['courseCode']) // Replace spaces with _ and trim off section
-    courseNode.querySelector('a.r').href = "http://claremontreview.com/courses/" + course.data['courseCode'].replace(/\s/g, '_').slice(0, -3);
+    courseNode.querySelector('a.r').href = "http://claremontreview.com/courses/" + course.data['courseCode'].replace(/(\s)+/g, '_').slice(0, -3);
   courseNode.querySelector('#course-review').style.backgroundColor = courseNode.querySelector('input[type="text"]').style.backgroundColor;
   if (options.showReviewLinks) courseNode.querySelector('#course-review').style.display = "block";
   else courseNode.querySelector('input[type="text"]').classList.remove('withReview');
@@ -546,7 +546,7 @@ function messageOnce(str) {
         courseReviewNodes[i].style.display = "none";
       }
     }
-    
+
     localStorage.showReviewLinks = options.showReviewLinks = this.checked;
     document.getElementById('button-generate').onclick();
   };


### PR DESCRIPTION
ClaremontReview is a 7C course review site that allows students past and present to share their experiences in 7C courses with their peers. A course review site is a great resource when trying to decide what classes one want to take and they do not have direct access to someone else who has already been through the course.

This pull request add the option to display course links (located next to each courseNode) directly from the scheduler to the ClaremontReview course page. This gives students easier access to their peer experience in a space that they are most likely to need it. If, however, the user does not what the links to be displayed, they can be disabled using the check option which basically reverts the scheduler to its old state.

Minor bug fixes:
* Fixed options checkbox displaying (see #8 ; 741b276 )
* Remove incorrect label title + extra white space + indentation (0ffa26c & d10cfac)